### PR TITLE
Usage type defaults

### DIFF
--- a/config.js
+++ b/config.js
@@ -41,7 +41,9 @@ module.exports = {
 	// A hash of parameters to provide with every GET request made to the API
 	//
 	// @type {Object} A hash contining querystring parameters
-	defaultParams: {},
+	defaultParams: {
+		usageTypes: 'download'
+	},
 	// A hash of custom headers to provide with every request made to the API
 	//
 	// @type {Object} A hash contining the headers

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "7digital-api",
-  "version": "0.35.6",
+  "version": "1.0.0",
   "description": "7digital API client for nodeJS",
   "homepage": "https://github.com/raoulmillais/7digital-api",
   "repository": {

--- a/test/build-test.js
+++ b/test/build-test.js
@@ -254,14 +254,16 @@ describe('API.build', function() {
 		assert.equal(testApi3.logger.label, 'logger2');
 
 		assert.deepEqual(testApi.defaultParams, {
-			pageSize: 5
+			pageSize: 5,
+			usageTypes: 'download'
 		});
 		assert.deepEqual(testApi.headers, {
 			'resource-header':1
 		});
 		assert.deepEqual(testApi2.defaultParams, {
 			page: 2,
-			pageSize: 6
+			pageSize: 6,
+			usageTypes: 'download'
 		});
 		assert.deepEqual(testApi2.headers, {
 			'resource-header': 2,
@@ -270,7 +272,8 @@ describe('API.build', function() {
 		assert.deepEqual(testApi3.defaultParams, {
 			page: 2,
 			pageSize: 7,
-			country: 'fr'
+			country: 'fr',
+			usageTypes: 'download'
 		});
 		assert.deepEqual(testApi3.headers, {
 			'resource-header': 3,

--- a/test/config-test.js
+++ b/test/config-test.js
@@ -45,5 +45,8 @@ describe('config', function() {
 	it('should have the response format set to JSON by default', function () {
 		assert.equal(config.format, 'json');
 	});
-
+	
+	it('should default to using the download usage type', function () {
+		assert.deepEqual(config.defaultParams, {usageTypes: 'download'});
+	});
 });


### PR DESCRIPTION
As we are trying to deprecate calls to the api without the usage types parameter, include a sensible default of download. This is a major version bump as it changes the schema of existing responses.
