### PR TITLE
Using Upper case for headers first letters

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -39,7 +39,7 @@ function prepare(data, consumerkey) {
 // - @return {Object}
 function createHeaders(host, headers) {
 	return _.extend({}, headers, {
-		'host': host,
+		'Host': host,
 		'User-Agent' : USER_AGENT
 	});
 }

--- a/test/request-test.js
+++ b/test/request-test.js
@@ -11,7 +11,7 @@ describe('request', function () {
 
 		it('adds the user agent and host headers', function () {
 			var headers  = request.createHeaders('api.7digital.com');
-			assert.equal(headers.host, 'api.7digital.com');
+			assert.equal(headers.Host, 'api.7digital.com');
 			assert.equal(headers['User-Agent'], 'Node.js HTTP Client');
 		});
 


### PR DESCRIPTION
For some reason, an API call leads to the Host headers being set twice leading to issues with HTTP request mock tools like `nock`: https://github.com/node-nock/nock/issues/804

Here is a fix for this problem.